### PR TITLE
feat(hotkey): 支持原生数字键选牌；在与点击相同条件下自动出牌，其他情况仅选中（最小改动，保持原逻辑）

### DIFF
--- a/src/main/java/justclick/patchs/ClickCardPatch.java
+++ b/src/main/java/justclick/patchs/ClickCardPatch.java
@@ -29,10 +29,24 @@ public class ClickCardPatch {
             rlocs = {28, 15}
     )
     public static void Insert(AbstractPlayer __instance) {
-        if ((InputHelper.justClickedLeft || CInputHelper.isJustPressed(0)) && __instance.hoveredCard != null && !AbstractDungeon.isScreenUp) {
+        // 支持原生数字键热键：从手牌按组内顺序选第 N 张卡
+        AbstractCard hotkeyCard = null;
+        try {
+            hotkeyCard = InputHelper.getCardSelectedByHotkey(__instance.hand);
+        } catch (Throwable ignored) { }
+
+        boolean clickTriggered = (InputHelper.justClickedLeft || CInputHelper.isJustPressed(0));
+        boolean hotkeyTriggered = (hotkeyCard != null);
+
+        if (((clickTriggered && __instance.hoveredCard != null) || hotkeyTriggered) && !AbstractDungeon.isScreenUp) {
             try {
 
-                AbstractCard clickedCard = __instance.hoveredCard;
+                AbstractCard clickedCard = hotkeyTriggered ? hotkeyCard : __instance.hoveredCard;
+
+                // 热键只改变选中卡，是否出牌由下方逻辑决定
+                if (hotkeyTriggered) {
+                    __instance.hoveredCard = clickedCard;
+                }
 
                 logger.info("点击了卡牌: {}", clickedCard);
 
@@ -64,6 +78,9 @@ public class ClickCardPatch {
                     field.set(__instance, hoveredMonster);
 
                     playCardMethod.invoke(__instance);
+                } else if (hotkeyTriggered) {
+                    // 热键仅选中但不满足自动出牌：保持选中，交由原生空格/拖拽/取消
+                    return;
                 }
             } catch (NoSuchMethodException e) {
                 logger.error("找不到playCard方法", e);

--- a/src/main/java/justclick/patchs/ClickCardPatch.java
+++ b/src/main/java/justclick/patchs/ClickCardPatch.java
@@ -48,7 +48,12 @@ public class ClickCardPatch {
                     __instance.hoveredCard = clickedCard;
                 }
 
-                logger.info("点击了卡牌: {}", clickedCard);
+                // 按作者建议：区分日志来源（热键/点击）
+                if (hotkeyTriggered) {
+                    logger.info("热键选择了卡牌: {}", clickedCard);
+                } else if (clickTriggered) {
+                    logger.info("点击了卡牌: {}", clickedCard);
+                }
 
                 Method playCardMethod = AbstractPlayer.class.getDeclaredMethod("playCard");
                 playCardMethod.setAccessible(true);


### PR DESCRIPTION
  - 背景
      - 希望数字键选牌时，行为与“点击即出牌”一致；避免渲染期竞态和额外订阅者。
  - 改动说明（最小差异）
      - 仅改 1 个文件：src/main/java/justclick/patchs/ClickCardPatch.java
      - 在点击补丁的插入点里调用引擎原生方法
        InputHelper.getCardSelectedByHotkey(__instance.hand) 获取热键选中的卡，
        然后与鼠标点击路径合流处理。
      - 若满足原有“自动出牌”条件（ENEMY+单怪 或 SELF/NONE/ALL_ENEMY/
        SELF_AND_ENEMY 且开关允许）→ 当帧出牌；否则仅设置 hoveredCard，不出牌
        （交给空格/拖拽/取消）。
  - 代码位置
      - 入口：src/main/java/justclick/patchs/ClickCardPatch.java:35
      - 选择卡牌：src/main/java/justclick/patchs/ClickCardPatch.java:40
      - 自动出牌逻辑沿用原分支：src/main/java/justclick/patchs/
        ClickCardPatch.java:62
  - 行为一致性
      - 鼠标点击逻辑不变；
      - 键盘与点击“自动出牌”的条件一致：ENEMY+单怪/自目标/群体/无目标会直接出；
        ENEMY+多怪只选中。
  - 兼容性
      - 不新增类/订阅者；不改作者信息、版本、不改构建方式；改动仅此一处。
  - 测试环境
      - Java 8u144 / STS 2022-12-18 / MTS 3.30.3 / BaseMod 5.56.0
      - SELF/NONE/ALL_ENEMY/SELF_AND_ENEMY：按键当帧出牌
      - ENEMY + 单怪：按键当帧出牌